### PR TITLE
Added option to add department brochure links and changed resume rename to use roll number instead of username

### DIFF
--- a/backend/main/models.py
+++ b/backend/main/models.py
@@ -292,6 +292,7 @@ class CourseHighlights(models.Model):
     program = models.CharField(max_length=64)
     title = models.CharField(max_length=64)
     description = RichTextUploadingField()
+    brochure = models.FileField(upload_to='department_brochure', null=True, blank=True)
 
     def __str__(self):
         return self.title

--- a/backend/student/models.py
+++ b/backend/student/models.py
@@ -101,11 +101,11 @@ pre_save.connect(event_pre_save_receiver_student, sender=StudentProfile)
 def event_pre_save_receiver_resume(sender, instance, *args, **kwargs):
     if instance.student.user.first_name not in instance.file.name or \
             instance.student.user.last_name not in instance.file.name or \
-            instance.student.user.username not in instance.file.name or \
+            instance.student.roll_no not in instance.file.name or \
             'IITJodhpur.pdf' not in instance.file.name \
             and instance._state.adding is True:
         instance.file.name = instance.student.user.first_name + '_' + instance.student.user.last_name \
-            + '_' + instance.student.user.username + '_' + str(random.randint(1, 10001)) + \
+            + '_' + instance.student.roll_no + '_' + str(random.randint(1, 10001)) + \
             '_' + 'IITJodhpur.pdf'
     if not instance.reference:
         instance.reference = instance.file.name

--- a/frontend/src/components/CourseCard.js
+++ b/frontend/src/components/CourseCard.js
@@ -6,6 +6,7 @@ import AccordionDetails from '@material-ui/core/AccordionDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import FadeUpWhenVisible from '../components/Animation/FadeUp';
 import FadeInWhenVisible from '../components/Animation/FadeIn';
+import { getLink } from '../utils/getLink';
 
 const CourseCard = ({ data }) => {
   return (
@@ -18,12 +19,26 @@ const CourseCard = ({ data }) => {
         >
           <div className={styles.department}>{data.title}</div>
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails
+          style={{ justifyContent: 'center', textAlign: 'center' }}
+        >
           <FadeInWhenVisible>
-            <div
-              className={styles.description}
-              dangerouslySetInnerHTML={{ __html: data.description }}
-            />
+            {data.brochure ? (
+              <a
+                className={styles.brochure}
+                href={getLink(data.brochure)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Click here to view the Departmental Brochure
+                <i className="fa fa-external-link-alt"></i>
+              </a>
+            ) : (
+              <div
+                className={styles.description}
+                dangerouslySetInnerHTML={{ __html: data.description }}
+              />
+            )}
           </FadeInWhenVisible>
         </AccordionDetails>
       </Accordion>

--- a/frontend/src/components/StudentDashboard/UplaodResume.js
+++ b/frontend/src/components/StudentDashboard/UplaodResume.js
@@ -160,12 +160,12 @@ function UploadResume() {
       </Grid>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
         <Alert onClose={handleClose} severity="success">
-          Resume Uplaoded Suceessfully!
+          Resume Uploaded Suceessfully!
         </Alert>
       </Snackbar>
       <Snackbar open={error} autoHideDuration={6000} onClose={handleCloseerror}>
         <Alert onClose={handleCloseerror} severity="error">
-          Resume Upload Failed Try Later
+          Resume Upload Failed, Try Again Later
         </Alert>
       </Snackbar>
     </Grid>

--- a/frontend/src/styles/components/CourseCard.module.css
+++ b/frontend/src/styles/components/CourseCard.module.css
@@ -19,3 +19,22 @@
 .description > p {
   margin-top: 0;
 }
+
+.brochure {
+  width: 100%;
+  text-align: center;
+  margin: 0 auto 0.5rem auto;
+  color: black;
+  text-decoration: underline 0.1rem white;
+  transition: text-decoration-color 500ms, text-underline-offset 500ms;
+}
+
+.brochure > i {
+  margin-left: 0.2rem;
+}
+
+.brochure:hover {
+  color: #012970;
+  text-decoration-color: #012970;
+  text-underline-offset: 0.3rem;
+}


### PR DESCRIPTION
- Added option to either display course content and departmental brochure link
- Initially, we were including the username to rename the resume. Now we are using roll number. But why? Because the username of branch changers is old roll number and since we need to use new roll number, hence we include roll number instead of username.